### PR TITLE
Add guardrail policies to packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -42,5 +42,29 @@
     {
         "name": "ratelimit-ai-token-based-ratelimit",
         "version": "1.0.0"
+    },
+    {
+        "name": "guardrail-regex-guardrail",
+        "version": "0.0.1"
+    },
+    {
+        "name": "guardrail-word-count-guardrail",
+        "version": "0.0.1"
+    },
+    {
+        "name": "guardrail-sentence-count-guardrail",
+        "version": "0.0.1"
+    },
+    {
+        "name": "guardrail-content-length-guardrail",
+        "version": "0.0.1"
+    },
+    {
+        "name": "guardrail-url-guardrail",
+        "version": "0.0.1"
+    },
+    {
+        "name": "guardrail-azure-content-safety-content-moderation",
+        "version": "0.0.1"
     }
 ]


### PR DESCRIPTION
## Purpose
This PR adds the following policies to the packages.json file.

- Regex Guardrail
- Word Count Guardrail
- Sentence Count Guardrail
- Content Length Guardrail
- URL Guardrail
- Azure Content Safety Content Moderation

Related issue: https://github.com/wso2/api-manager/issues/3951